### PR TITLE
Use builtin OpenAI plugin. Adds tool support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies for building (if needed)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-copy only files needed for dependency resolution
+COPY pyproject.toml ./
+
+# Install Python dependencies
+RUN pip install --upgrade pip \
+    && pip install flake8 pytest \
+    && pip install .
+
+# Now copy the rest of the source code
+COPY README.md llm_github_copilot.py run-tests.sh ./
+COPY tests/ ./tests/
+
+ENV PYTHONPATH=/app
+
+CMD ["/app/run-tests.sh"]
+

--- a/README.md
+++ b/README.md
@@ -169,3 +169,11 @@ If you want to record new VCR cassettes for tests, set your API key:
 export PYTEST_GITHUB_COPILOT_TOKEN=your_token_here
 pytest --vcr-record=new_episodes
 ```
+
+You can also run the tests in a containerized environment to avoid
+contamination from the environment (e.g. auth keys/files):
+
+```
+docker build -t llm-github-copilot-test .
+docker run -it llm-github-copilot-test
+```

--- a/llm_github_copilot.py
+++ b/llm_github_copilot.py
@@ -467,7 +467,7 @@ class GitHubCopilotAuthenticator:
             return None
 
 
-class _GitHubCopilot(llm.default_plugins.openai_models.Chat):
+class _GitHubCopilot():
     """
     GitHub Copilot model implementation for LLM.
     """

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -ex
+
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+pytest -vv --durations=10

--- a/tests/test_github_copilot.py
+++ b/tests/test_github_copilot.py
@@ -40,6 +40,9 @@ def test_prompt():
         "llm_github_copilot.fetch_models_data",
         return_value=MOCK_MODEL_DATA,
     ), patch(
+        "llm_github_copilot.GitHubCopilotAuthenticator.has_valid_credentials",
+        return_value=True,
+    ), patch(
         "llm_github_copilot.GitHubCopilotAuthenticator.get_api_key",
         return_value=GITHUB_COPILOT_TOKEN,
     ):
@@ -61,6 +64,9 @@ def test_model_variants():
     ), patch(
         "llm_github_copilot.GitHubCopilotAuthenticator.has_valid_credentials",
         return_value=True,
+    ), patch(
+        "llm_github_copilot.GitHubCopilotAuthenticator.get_api_key",
+        return_value=GITHUB_COPILOT_TOKEN,
     ):
         # Test that the default model exists
         default_model = llm.get_model(DEFAULT_MODEL)
@@ -84,6 +90,9 @@ def test_options():
     with patch(
         "llm_github_copilot.fetch_models_data",
         return_value=MOCK_MODEL_DATA,
+    ), patch(
+        "llm_github_copilot.GitHubCopilotAuthenticator.has_valid_credentials",
+        return_value=True,
     ), patch(
         "llm_github_copilot.GitHubCopilotAuthenticator.get_api_key",
         return_value=GITHUB_COPILOT_TOKEN,

--- a/tests/test_github_copilot_cli.py
+++ b/tests/test_github_copilot_cli.py
@@ -113,8 +113,8 @@ class TestAuthLogin:
 
         # Mock fetch_available_models
         with patch(
-            "llm_github_copilot.fetch_available_models",
-            return_value={"github-copilot", "github-copilot/gpt-4o"},
+            "llm_github_copilot.fetch_models_data",
+            return_value={"data": [{"id": "o3-mini"}]},
         ):
             # Create a mock CLI command
             @click.command()
@@ -124,7 +124,7 @@ class TestAuthLogin:
                 access_token = mock_authenticator._login()
                 api_key_info = mock_authenticator._refresh_api_key()
                 click.echo("GitHub Copilot login process completed successfully!")
-                models = llm_github_copilot.fetch_available_models(mock_authenticator)
+                models = llm_github_copilot.fetch_models_data(mock_authenticator)
                 click.echo(f"Available models: {', '.join(models)}")
 
             # Run the command
@@ -553,7 +553,7 @@ class TestModelsCommand:
     def mock_registered_models(self):
         """Fixture for mock registered LLM models."""
         model1 = MagicMock(spec=llm.Model)
-        model1.model_id = "github_copilot"
+        model1.model_id = "github_copilot/gpt-4o"
         model2 = MagicMock(spec=llm.Model)
         model2.model_id = "github_copilot/claude-3-7-sonnet"
         other_model = MagicMock(spec=llm.Model)
@@ -581,18 +581,12 @@ class TestModelsCommand:
         self, cli_runner, mock_authenticator, mock_registered_models, mock_models_data
     ):
         """Test 'models --verbose' when authenticated."""
+        print(f"JOEL here1")
         mock_authenticator.has_valid_credentials.return_value = True
         with (
             patch("llm.get_models", return_value=mock_registered_models),
             patch(
-                "llm_github_copilot._fetch_models_data", return_value=mock_models_data
-            ),
-            patch(
-                "llm_github_copilot.GitHubCopilot.get_model_mappings",
-                return_value={
-                    "github_copilot": "gpt-4o",
-                    "github_copilot/claude-3-7-sonnet": "claude-3-7-sonnet",
-                },
+                "llm_github_copilot.fetch_models_data", return_value=mock_models_data
             ),
         ):
             result = cli_runner.invoke(
@@ -617,7 +611,7 @@ class TestModelsCommand:
         with (
             patch("llm.get_models", return_value=mock_registered_models),
             patch(
-                "llm_github_copilot._fetch_models_data", return_value=mock_models_data
+                "llm_github_copilot.fetch_models_data", return_value=mock_models_data
             ),
         ):
             result = cli_runner.invoke(
@@ -674,7 +668,7 @@ class TestModelsCommand:
         with (
             patch("llm.get_models", return_value=mock_registered_models),
             patch(
-                "llm_github_copilot._fetch_models_data",
+                "llm_github_copilot.fetch_models_data",
                 side_effect=Exception("API Error"),
             ),
         ):
@@ -694,7 +688,7 @@ class TestModelsCommand:
         with (
             patch("llm.get_models", return_value=mock_registered_models),
             patch(
-                "llm_github_copilot._fetch_models_data",
+                "llm_github_copilot.fetch_models_data",
                 side_effect=Exception("API Error"),
             ),
         ):


### PR DESCRIPTION
The GitHub Copilot completions (`/chat/completions`) API is based on the OpenAI API regardless of whether the backend model is an OpenAI one or not. This means we can greatly simplify the GitHub Copilot plugin by using the builtin OpenAI plugin (`llm.default_plugins.openai_models`) for everything except for the Copilot device-based authentication.

In addition to the significant simplification and code reduction, one key benefit of this approach is that we automatically get additional functionality that is implemented by the openai_models plugin such as tool calling, async, schema/structured output, etc. We should also get any future OpenAI plugin functionality automatically (or with minimal changes).

Tests have been updated to remove most of the completion tests since this should now be covered by tests in OpenAI plugin itself. Minor updates were needed to the authentication and the CLI tests to get them to work simplified code base.

Finally, the fetch_models_data top-level function (wraps _fetch_models_data) has been memoized so that the model data is cached after the first call.

NOTES:
* To support tool calls in non OpenAI models, this change is needed in llm itself: https://github.com/simonw/llm/pull/1170 However, this change isn't dependent on that one (but once it's merge tool calls will work in anthropic models too).
* I haven't bumped the version as part of this PR but that should happen before this is released to pypi of course.
* I removed the use of "github_copilot" as a default model. Trying to keep it was increasing the complexity of the result quite a bit. However, I don't feel strongly about that if somebody else wants to add it back.